### PR TITLE
[Cherrypick] CI: Fix for v1.1-branch CI, broken due to gdbgui (#28507)

### DIFF
--- a/.github/workflows/chef.yaml
+++ b/.github/workflows/chef.yaml
@@ -91,6 +91,8 @@ jobs:
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
             - name: CI Examples ESP32
               shell: bash
               run: |

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -51,6 +51,9 @@ jobs:
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --allow-changing-global-git-config --shallow --platform esp32
 
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+
             - name: Set up environment for size reports
               if: ${{ !env.ACT }}
               env:
@@ -195,6 +198,9 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
+
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
 
             - name: Build example Bridge App
               timeout-minutes: 15

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -75,6 +75,9 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
 
+            - name: Fixup GdbGui requirement
+              run: perl -i -pe 's/^gdbgui==/# gdbgui==/' /opt/espressif/esp-idf/requirements.txt
+
             - name: Build ESP32 QEMU test images
               timeout-minutes: 20
               run: |

--- a/scripts/setup/requirements.esp32.txt
+++ b/scripts/setup/requirements.esp32.txt
@@ -9,4 +9,10 @@ ecdsa>=0.16.0
 kconfiglib==13.7.1
 construct==2.10.54
 python-socketio<5
-gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+itsdangerous<2.1 ; python_version < "3.11"
+#
+# gdbgui pulls in gevent which fails to compile due to cython updates.
+# Could not find a good way to fix this dependency, so commenting it
+# out here.
+#
+# gdbgui==0.13.2.0 ; python_version < "3.11" and platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
* ESP32: avoid installing gdbgui when not needed (#26542)

ESP-IDF v4.4.4 requires gdbgui only when Python before 3.11 is used (see https://github.com/espressif/esp-idf/commit/3974be7fec1ea6c529ecbee795c0152b42b61d55). Avoid installing it when not needed.

Fixes: #25385

* Remove gdbgui requirement for esp32 (#28007)

* Remove gdbgui requirement for esp32

* Fix qemu

* Fix chef as well

---------

> !!!!!!!!!! Please delete the instructions below and replace with PR description
>
> If you have an issue number, please use a syntax of
> `Fixes #12345` and a brief change description
>
> If you do not have an issue number, please have a good description of
> the problem and the fix. Help the reviewer understand what to expect.
>
> Make sure you delete these instructions (to prove you have read them).
>
> !!!!!!!!!! Instructions end

